### PR TITLE
feat: (DHEI-15238) Add graceful shutdown with kafka producing equival…

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,12 @@ spring:
       url: ${STARLIGHT_REPORTING_REDIS_URL}
   main:
     banner-mode: off
+  lifecycle:
+    timeout-per-shutdown-phase: ${STARLIGHT_PUBLISHING_TIMEOUT_MS:30000}ms
+
+server:
+  shutdown: graceful
+
 logging:
   level:
     root: ${LOG_LEVEL:INFO}


### PR DESCRIPTION
…ent timeout

Activate graceful shutdown and use kafka producing timeout value for shutdown-timeout value.

At best this is used together with a small wait time for shutting down a starlight pod before emitting sigterm to starlight.

see linked PR in helm chart https://github.com/telekom/pubsub-horizon-helm-charts/pull/3 