### PR TITLE
feat(schema-validation): make schema enforcement configurable and add metrics for schema-violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ repositories {
 
 ext {
     // this is internal, overwrite with your specific implementation if you want
-    schemalValidationImplDependency = System.getenv('ADDITIONAL_SCHEMASTORE_IMPL') ?: System.getProperty("schemaStoreImplMavenDependency") ?: ""
+    schemaValidationImplDependency = System.getenv('ADDITIONAL_SCHEMASTORE_IMPL') ?: System.getProperty("schemaStoreImplMavenDependency") ?: ""
 }
 
 dependencies {
@@ -86,8 +86,8 @@ dependencies {
     implementation "de.telekom.eni:horizon-spring-boot-starter:${horizonParentVersion}"
 
     // optional
-    if (!schemalValidationImplDependency.allWhitespace) {
-        //implementation "${schemalValidationImplDependency}"
+    if (!schemaValidationImplDependency.allWhitespace) {
+        implementation "${schemaValidationImplDependency}"
     }
 
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 everitJsonVersion=1.14.4
-horizonParentVersion=5.1.0
+horizonParentVersion=5.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 everitJsonVersion=1.14.4
-horizonParentVersion=5.0.1
+horizonParentVersion=5.1.0

--- a/src/main/java/de/telekom/horizon/starlight/config/StarlightConfig.java
+++ b/src/main/java/de/telekom/horizon/starlight/config/StarlightConfig.java
@@ -20,6 +20,9 @@ public class StarlightConfig {
     @Value("${starlight.features.schemaValidation:true}")
     private boolean enableSchemaValidation;
 
+    @Value("${starlight.features.enforceSchemaValidation:false}")
+    private boolean enforceSchemaValidation;
+
     @Value("#{'${starlight.security.headerPropagationBlacklist}'.split(',')}")
     private List<String> headerPropagationBlacklist;
 

--- a/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
@@ -89,14 +89,6 @@ public class SchemaValidationService {
             } catch (JsonProcessingException | JSONException e) {
                 log.info(String.format("Event of type %s is no valid json.", event.getType()));
 
-                if (!starlightConfig.isEnforceSchemaValidation()) {
-                    log.warn("Schema validation is not enforced, ignoring invalid schema for event type {} in event {}", event.getType(), event.getId());
-                    metricsHelper.getRegistry()
-                            .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_FAILURES, "event_type", event.getType(), "publisher_id", publisherId)
-                            .increment();
-                    return;
-                }
-
                 throw new EventNotCompliantWithSchemaException(String.format("Event of type %s is no valid json.",
                         event.getType()), e);
             }

--- a/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
@@ -107,7 +107,7 @@ public class SchemaValidationService {
                         event.getType(), event.getId()));
 
                 metricsHelper.getRegistry()
-                        .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_FAILURES, "event_type", event.getType(), "publisher_id", publisherId)
+                        .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_FAILURE, "event_type", event.getType(), "publisher_id", publisherId)
                         .increment();
 
                 if (!starlightConfig.isEnforceSchemaValidation()) {

--- a/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
@@ -6,9 +6,12 @@ package de.telekom.horizon.starlight.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.telekom.eni.pandora.horizon.metrics.HorizonMetricsConstants;
+import de.telekom.eni.pandora.horizon.metrics.HorizonMetricsHelper;
 import de.telekom.eni.pandora.horizon.model.event.Event;
 import de.telekom.eni.pandora.horizon.schema.SchemaStore;
 import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
+import de.telekom.horizon.starlight.config.StarlightConfig;
 import de.telekom.horizon.starlight.exception.EventNotCompliantWithSchemaException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -33,11 +36,17 @@ public class SchemaValidationService {
 
     private final SchemaStore schemaStore;
 
+    private final StarlightConfig starlightConfig;
+
+    private final HorizonMetricsHelper metricsHelper;
+
     private final HorizonTracer tracer;
 
     @Autowired
-    public SchemaValidationService(SchemaStore schemaStore, HorizonTracer tracer) {
+    public SchemaValidationService(SchemaStore schemaStore, StarlightConfig starlightConfig, HorizonMetricsHelper metricsHelper, HorizonTracer tracer) {
         this.schemaStore = schemaStore;
+        this.starlightConfig = starlightConfig;
+        this.metricsHelper = metricsHelper;
         this.tracer = tracer;
     }
 
@@ -79,6 +88,15 @@ public class SchemaValidationService {
                 jsonEvent = new JSONObject(new ObjectMapper().writeValueAsString(event.getData()));
             } catch (JsonProcessingException | JSONException e) {
                 log.info(String.format("Event of type %s is no valid json.", event.getType()));
+
+                if (!starlightConfig.isEnforceSchemaValidation()) {
+                    log.warn("Schema validation is not enforced, ignoring invalid schema for event type {} in event {}", event.getType(), event.getId());
+                    metricsHelper.getRegistry()
+                            .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_FAILURES, "event_type", event.getType(), "publisher_id", publisherId)
+                            .increment();
+                    return;
+                }
+
                 throw new EventNotCompliantWithSchemaException(String.format("Event of type %s is no valid json.",
                         event.getType()), e);
             }
@@ -86,11 +104,25 @@ public class SchemaValidationService {
             try {
                 schemaCacheInstance.validate(jsonEvent);
                 currentSpan.ifPresent(s -> tracer.addTagsToSpan(s, List.of(Pair.of("isMatchingSchema", "true"))));
+                metricsHelper.getRegistry()
+                        .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_SUCCESS, "event_type", event.getType(), "publisher_id", publisherId)
+                        .increment();
+
             } catch (ValidationException ex) {
                 currentSpan.ifPresent(s -> tracer.addTagsToSpan(s, List.of(Pair.of("isMatchingSchema", "false"))));
 
                 log.info(String.format("Event of type %s with id %s does not comply with the given schema.",
                         event.getType(), event.getId()));
+
+                metricsHelper.getRegistry()
+                        .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_FAILURES, "event_type", event.getType(), "publisher_id", publisherId)
+                        .increment();
+
+                if (!starlightConfig.isEnforceSchemaValidation()) {
+                    log.warn("Schema validation is not enforced, skipping compliance check for event of type {} with id {}", event.getType(), event.getId());
+                    return;
+                }
+
                 throw new EventNotCompliantWithSchemaException(String.format("Event of type %s with id %s does not comply with the given schema.",
                         event.getType(), event.getId()), ex);
             }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -51,6 +51,7 @@ starlight:
   features:
     publisherCheck: ${STARLIGHT_FEATURE_PUBLISHER_CHECK:true}
     schemaValidation: ${STARLIGHT_FEATURE_SCHEMA_VALIDATION:false}
+    enforceSchemaValidation: ${STARLIGHT_FEATURE_ENFORCE_SCHEMA_VALIDATION:false}
   security:
     # Must be lower-case and comma-separated, can be regex
     headerPropagationBlacklist: ${STARLIGHT_HEADER_PROPAGATION_BLACKLIST:x-spacegate-token,authorization,content-length,host,accept.*,x-forwarded.*,cookie}

--- a/src/test/java/de/telekom/horizon/starlight/service/SchemaValidationServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/SchemaValidationServiceTest.java
@@ -36,7 +36,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class SchemeValidationServiceTest {
+class SchemaValidationServiceTest {
 
     public static final String PUB_ID_MOCK = "pub--id--mock";
     public static final String ENV_MOCK = "mock";


### PR DESCRIPTION
This PR introduces the following changes:

- The new option `STARLIGHT_FEATURE_ENFORCE_SCHEMA_VALIDATION` which is used to control whether schema violations will be treated as bad requests or not.
- Two new for identifying schema violations based on event-type and publisher-id
    - `METRIC_SCHEMA_VALIDATION_FAILURE`: Represents the times a schema-validation has failed due to a non-compliant JSON body.
    - `METRIC_SCHEMA_VALIDATION_SUCCESS`: Represents the times a schema-validation has succeeded due to a compliant JSON body.
