### PR TITLE
refactor: improve Kafka publishing, DI, and header matching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 everitJsonVersion=1.14.4
-horizonParentVersion=5.1.1
+horizonParentVersion=5.1.2

--- a/src/main/java/de/telekom/horizon/starlight/api/EventController.java
+++ b/src/main/java/de/telekom/horizon/starlight/api/EventController.java
@@ -71,8 +71,6 @@ public class EventController {
     private void addTracingTags(Event event) {
         var currentSpan = Optional.ofNullable(tracer.getCurrentSpan());
 
-        log.info("currentSpan: {}", tracer.getCurrentSpan());
-
         currentSpan.ifPresent(s -> tracer.addTagsToSpan(s, List.of(
                 Pair.of("eventType", event.getType()),
                 Pair.of("eventId", event.getId())

--- a/src/main/java/de/telekom/horizon/starlight/api/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/de/telekom/horizon/starlight/api/RestResponseEntityExceptionHandler.java
@@ -75,7 +75,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     @ExceptionHandler(CouldNotPublishEventMessageException.class)
     @ResponseStatus(HttpStatus.GATEWAY_TIMEOUT)
     protected ResponseEntity<Object> handleCouldNotPublishEventMessageException(CouldNotPublishEventMessageException e, WebRequest request) {
-        log.error("Horizon Starlight error occurred while writing to kafka: " + e.getMessage(), e);
+        log.error("Horizon Starlight error occurred while writing to kafka: {}", e.getMessage(), e);
 
         return responseEntityForException(e, HttpStatus.GATEWAY_TIMEOUT, request, null);
     }
@@ -84,7 +84,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     @ExceptionHandler(HorizonStarlightException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected ResponseEntity<Object> handleHorizonStarlightException(HorizonStarlightException e, WebRequest request) {
-        log.error("Horizon Starlight error occurred: " + e.getMessage(), e);
+        log.error("Horizon Starlight error occurred: {}", e.getMessage(), e);
 
         return responseEntityForException(e, HttpStatus.INTERNAL_SERVER_ERROR, request, null);
     }
@@ -93,7 +93,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     protected ResponseEntity<Object> handleAny(Exception e, WebRequest request) {
-        log.error("Error occurred: " + e.getMessage(), e);
+        log.error("Error occurred: {}", e.getMessage(), e);
 
         var headers = new HttpHeaders();
 
@@ -107,7 +107,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
             } else {
                 status = HttpStatus.INTERNAL_SERVER_ERROR;
             }
-        } catch(Exception unknownException) {
+        } catch (Exception unknownException) {
             status = HttpStatus.INTERNAL_SERVER_ERROR;
         }
 

--- a/src/main/java/de/telekom/horizon/starlight/config/StarlightConfig.java
+++ b/src/main/java/de/telekom/horizon/starlight/config/StarlightConfig.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 @Configuration
@@ -30,6 +31,8 @@ public class StarlightConfig {
 
     private List<Pattern> compiledHeaderPropagationBlacklist;
 
+    private Predicate<String> headerBlacklistPredicate;
+
     @Value("${starlight.defaultEnvironment}")
     private String defaultEnvironment;
 
@@ -47,6 +50,11 @@ public class StarlightConfig {
         compiledHeaderPropagationBlacklist = headerPropagationBlacklist.stream()
                 .map(Pattern::compile)
                 .toList();
+
+        headerBlacklistPredicate = compiledHeaderPropagationBlacklist.stream()
+                .map(Pattern::asMatchPredicate)
+                .reduce(Predicate::or)
+                .orElse(s -> false);
     }
 
 }

--- a/src/main/java/de/telekom/horizon/starlight/config/StarlightConfig.java
+++ b/src/main/java/de/telekom/horizon/starlight/config/StarlightConfig.java
@@ -4,11 +4,13 @@
 
 package de.telekom.horizon.starlight.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Configuration
 @Getter
@@ -26,19 +28,25 @@ public class StarlightConfig {
     @Value("#{'${starlight.security.headerPropagationBlacklist}'.split(',')}")
     private List<String> headerPropagationBlacklist;
 
+    private List<Pattern> compiledHeaderPropagationBlacklist;
+
     @Value("${starlight.defaultEnvironment}")
     private String defaultEnvironment;
 
     @Value("${starlight.publishingTopic:published}")
     private String publishingTopic;
 
-    @Value("${starlight.publishingTimeout}")
-    private Integer starlightTimeout;
-
     @Value("${starlight.defaultMaxPayloadSize}")
     private Long defaultMaxPayloadSize;
 
     @Value("#{'${starlight.payloadCheckExemptionList}'.split(',')}")
     private List<String> payloadCheckExemptionList;
+
+    @PostConstruct
+    void init() {
+        compiledHeaderPropagationBlacklist = headerPropagationBlacklist.stream()
+                .map(Pattern::compile)
+                .toList();
+    }
 
 }

--- a/src/main/java/de/telekom/horizon/starlight/service/PublisherService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/PublisherService.java
@@ -165,8 +165,6 @@ public class PublisherService {
 
             span.annotate("export metrics");
             metricsHelper.getRegistry().counter(METRIC_PUBLISHED_EVENTS, metricsHelper.buildTagsFromPublishedEventMessage(message)).increment();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
         } catch (Exception e) {
             span.error(e);
             handlePublishException(e);

--- a/src/main/java/de/telekom/horizon/starlight/service/PublisherService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/PublisherService.java
@@ -73,7 +73,8 @@ public class PublisherService {
             HorizonTracer tracer,
             HorizonMetricsHelper metricsHelper,
             EventWriter eventWriter,
-            Validator validator
+            Validator validator,
+            ObjectMapper objectMapper
     ) {
         this.publisherCache = publisherCache;
         this.starlightConfig = starlightConfig;
@@ -82,7 +83,7 @@ public class PublisherService {
         this.metricsHelper = metricsHelper;
         this.eventWriter = eventWriter;
         this.validator = validator;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -160,7 +161,7 @@ public class PublisherService {
             tracer.addTagsToSpan(span, List.of(Pair.of("publisherId", publisherId)));
 
             span.annotate("send message to kafka");
-            eventWriter.send(starlightConfig.getPublishingTopic(), message, tracer).get(this.starlightConfig.getStarlightTimeout(), TimeUnit.MILLISECONDS);
+            eventWriter.send(starlightConfig.getPublishingTopic(), message, tracer).get();
 
             span.annotate("export metrics");
             metricsHelper.getRegistry().counter(METRIC_PUBLISHED_EVENTS, metricsHelper.buildTagsFromPublishedEventMessage(message)).increment();
@@ -205,7 +206,7 @@ public class PublisherService {
 
         if (httpHeaders != null) {
             httpHeaders.forEach((k, v) -> {
-                if (starlightConfig.getHeaderPropagationBlacklist().stream().noneMatch(k::matches)) {
+                if (starlightConfig.getCompiledHeaderPropagationBlacklist().stream().noneMatch(p -> p.matcher(k).matches())) {
                     var unqiueValues = v.stream().distinct().toList();
                     unqiueValues.forEach(e -> filteredHeaders.add(k, e));
                 }

--- a/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
@@ -81,7 +81,7 @@ public class SchemaValidationService {
 
         var splitPubId = publisherId.split("--");
         if (splitPubId.length < 2 || Strings.isBlank(splitPubId[0]) || Strings.isBlank(splitPubId[1])) {
-            log.info(String.format("Schema validation is canceled because no schema can be clearly assigned to PublisherId %s", publisherId));
+            log.info("Schema validation is canceled because no schema can be clearly assigned to PublisherId {}", publisherId);
 
             return;
         }
@@ -109,7 +109,7 @@ public class SchemaValidationService {
                         new JSONObject(objectMapper.writeValueAsString(jsonNode)):
                         new JSONArray(objectMapper.writeValueAsString(jsonNode));
             } catch (JsonProcessingException | JSONException e) {
-                log.info(String.format("Event of type %s is no valid json.", event.getType()));
+                log.info("Event of type {} is no valid json.", event.getType());
 
                 throw new EventNotCompliantWithSchemaException(String.format("Event of type %s is no valid json.",
                         event.getType()), e);
@@ -125,8 +125,8 @@ public class SchemaValidationService {
             } catch (ValidationException ex) {
                 currentSpan.ifPresent(s -> tracer.addTagsToSpan(s, List.of(Pair.of("isMatchingSchema", "false"))));
 
-                log.info(String.format("Event of type %s with id %s does not comply with the given schema.",
-                        event.getType(), event.getId()));
+                log.info("Event of type {} with id {} does not comply with the given schema.",
+                        event.getType(), event.getId());
 
                 metricsHelper.getRegistry()
                         .counter(HorizonMetricsConstants.METRIC_SCHEMA_VALIDATION_FAILURE, "event_type", event.getType(), "publisher_id", publisherId)
@@ -141,8 +141,8 @@ public class SchemaValidationService {
                         event.getType(), event.getId()), ex);
             }
         } else {
-            log.debug(String.format("No spec found for event type %s in environment %s, skipping validation.",
-                    event.getType(), environment));
+            log.debug("No spec found for event type {} in environment {}, skipping validation.",
+                    event.getType(), environment);
         }
     }
 }

--- a/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/SchemaValidationService.java
@@ -49,12 +49,12 @@ public class SchemaValidationService {
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public SchemaValidationService(SchemaStore schemaStore, StarlightConfig starlightConfig, HorizonMetricsHelper metricsHelper, HorizonTracer tracer) {
+    public SchemaValidationService(SchemaStore schemaStore, StarlightConfig starlightConfig, HorizonMetricsHelper metricsHelper, HorizonTracer tracer, ObjectMapper objectMapper) {
         this.schemaStore = schemaStore;
         this.starlightConfig = starlightConfig;
         this.metricsHelper = metricsHelper;
         this.tracer = tracer;
-        this.objectMapper = new ObjectMapper();
+        this.objectMapper = objectMapper;
     }
 
     /**

--- a/src/main/java/de/telekom/horizon/starlight/service/impl/TokenServiceImpl.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/impl/TokenServiceImpl.java
@@ -6,7 +6,6 @@ package de.telekom.horizon.starlight.service.impl;
 
 import de.telekom.horizon.starlight.service.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -16,9 +15,10 @@ import java.security.Principal;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-@Profile("!publisher-mock")
 @Service
 public class TokenServiceImpl implements TokenService {
+
+    private static final Pattern REALM_PATTERN = Pattern.compile("^https://[\\w-.]+/auth/realms/(\\w+)$");
 
     private final HttpServletRequest request;
 
@@ -54,8 +54,7 @@ public class TokenServiceImpl implements TokenService {
         var token = getToken(principal);
 
         if (token != null && token.hasClaim(JwtClaimNames.ISS) ) {
-            var pattern = Pattern.compile("^https://[\\w-.]+/auth/realms/(\\w+)$");
-            var matcher = pattern.matcher(token.getIssuer().toString());
+            var matcher = REALM_PATTERN.matcher(token.getIssuer().toString());
 
             if (matcher.find()) {
                 return matcher.group(1);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
   main:
     banner-mode: off
   lifecycle:
-    timeout-per-shutdown-phase: ${STARLIGHT_PUBLISHING_TIMEOUT_MS:30000}ms
+    timeout-per-shutdown-phase: ${STARLIGHT_PUBLISHING_TIMEOUT_MS:46000}ms
 
 server:
   shutdown: graceful
@@ -30,8 +30,6 @@ management:
   endpoint:
     health:
       show-details: always
-    shutdown:
-      enabled: true
   health:
     redis:
       enabled: ${STARLIGHT_REPORTING_REDIS_ENABLED:false}
@@ -60,7 +58,6 @@ starlight:
     oauth: true
   defaultEnvironment: ${STARLIGHT_DEFAULT_ENVIRONMENT:integration}
   publishingTopic: ${STARLIGHT_PUBLISHING_TOPIC:published}
-  publishingTimeout: ${STARLIGHT_PUBLISHING_TIMEOUT_MS:5000}
   defaultMaxPayloadSize: ${STARLIGHT_DEFAULT_MAX_PAYLOAD_SIZE:1048576}
   payloadCheckExemptionList: ${STARLIGHT_PAYLOAD_CHECK_EXEMPTION_LIST:}
   reporting:
@@ -87,6 +84,7 @@ horizon:
     transactionIdPrefix: ${STARLIGHT_KAFKA_TRANSACTION_PREFIX:starlight}
     groupId: ${STARLIGHT_KAFKA_GROUP_ID:starlight}
     lingerMs: ${STARLIGHT_KAFKA_LINGER_MS:5}
+    deliveryTimeoutMs: ${STARLIGHT_KAFKA_DELIVERY_TIMEOUT_MS:45000}
     acks: ${STARLIGHT_KAFKA_ACKS:1}
     compression:
       enabled: ${STARLIGHT_KAFKA_COMPRESSION_ENABLED:false}

--- a/src/test/java/de/telekom/horizon/starlight/api/EventControllerIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/api/EventControllerIntegrationTest.java
@@ -5,9 +5,11 @@
 package de.telekom.horizon.starlight.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.telekom.eni.pandora.horizon.kafka.event.EventWriter;
 import de.telekom.eni.pandora.horizon.metrics.AdditionalFields;
 import de.telekom.eni.pandora.horizon.model.event.Event;
 import de.telekom.eni.pandora.horizon.model.event.PublishedEventMessage;
+import de.telekom.eni.pandora.horizon.tracing.HorizonTracer;
 import de.telekom.horizon.starlight.cache.PublisherCache;
 import de.telekom.horizon.starlight.service.TokenService;
 import de.telekom.horizon.starlight.service.reporting.ReportingService;
@@ -25,12 +27,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -50,6 +53,9 @@ class EventControllerIntegrationTest extends AbstractIntegrationTest {
 
     @SpyBean
     private ReportingService reportingService;
+
+    @SpyBean
+    private EventWriter eventWriter;
 
     private static final String DEFAULT_PUBLISHER = "eni--pandora--foobar";
 
@@ -179,6 +185,35 @@ class EventControllerIntegrationTest extends AbstractIntegrationTest {
         mockMvc.perform(head("/v1/integration/events"))
                 .andExpect(status().isNoContent())
                 .andExpect(header().exists("X-Health-Check-Timestamp"));
+    }
+
+    @Test
+    void testPublishShouldNotReturn201WhenInterruptedDuringKafkaSend() throws Exception {
+        when(publisherCache.findPublisherIds(any(), any())).thenReturn(Set.of(DEFAULT_PUBLISHER));
+
+        // Return a future whose .get() throws InterruptedException
+        CompletableFuture interruptedFuture = new CompletableFuture<>() {
+            @Override
+            public Object get() throws InterruptedException {
+                throw new InterruptedException("Thread was interrupted during Kafka send");
+            }
+        };
+        doReturn(interruptedFuture).when(eventWriter).send(anyString(), any(PublishedEventMessage.class), any(HorizonTracer.class));
+
+        // given
+        Event newEvent = HorizonTestHelper.createNewEvent();
+
+        // when / then - should NOT be 201 CREATED
+        mockMvc.perform(
+                post("/v1/integration/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer Foo")
+                        .content(objectMapper.writeValueAsString(newEvent))
+        ).andExpect(status().is5xxServerError());
+
+        // Verify that markEventProduced was NOT called since the publish failed
+        verify(reportingService, never()).markEventProduced(any(Event.class));
     }
 
 }

--- a/src/test/java/de/telekom/horizon/starlight/api/EventControllerIntegrationTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/api/EventControllerIntegrationTest.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +36,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ActiveProfiles("publisher-mock")
 @ExtendWith(HazelcastTestInstance.class)
 class EventControllerIntegrationTest extends AbstractIntegrationTest {
 

--- a/src/test/java/de/telekom/horizon/starlight/service/PublisherServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/PublisherServiceTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest(classes = {PublisherService.class, KafkaAutoConfiguration.class, LocalValidatorFactoryBean.class})
+@SpringBootTest(classes = {PublisherService.class, KafkaAutoConfiguration.class, LocalValidatorFactoryBean.class, ObjectMapper.class})
 @ExtendWith(HazelcastTestInstance.class)
 class PublisherServiceTest {
 

--- a/src/test/java/de/telekom/horizon/starlight/service/PublisherServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/PublisherServiceTest.java
@@ -121,6 +121,7 @@ class PublisherServiceTest {
         verify(publisherCache, times(isEnablePublisherCheck ? 1 : 0)).findPublisherIds(DEFAULT_ENVIRONMENT, message.getEvent().getType());
         verify(kafkaTemplate).send(any(ProducerRecord.class));
     }
+
     @Test
     @DisplayName("Event cannot be published due to a publisherId mismatch or an empty publisherId")
     void eventMessageCanBePublishedWithInvalidPublisherIdWhenCheckIsDisabled() {
@@ -196,7 +197,7 @@ class PublisherServiceTest {
 
             var responseFuture = mock(CompletableFuture.class);
             when(kafkaTemplate.send(any(ProducerRecord.class))).thenReturn(responseFuture);
-            when(responseFuture.get(anyLong(), any(TimeUnit.class))).thenThrow(new TimeoutException("I timed out writing to kafka"));
+            when(responseFuture.get()).thenThrow(new TimeoutException("I timed out writing to kafka"));
 
             publisherService.publish(event, DEFAULT_PUBLISHER_ID, DEFAULT_ENVIRONMENT, null);
         });

--- a/src/test/java/de/telekom/horizon/starlight/service/SchemaValidationServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/SchemaValidationServiceTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 
@@ -52,6 +54,9 @@ class SchemaValidationServiceTest {
 
     @Mock
     StarlightConfig starlightConfig;
+
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
 
     @InjectMocks
     SchemaValidationService schemaValidationService;

--- a/src/test/java/de/telekom/horizon/starlight/service/impl/TokenServiceMockImpl.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/impl/TokenServiceMockImpl.java
@@ -5,11 +5,6 @@
 package de.telekom.horizon.starlight.service.impl;
 
 import de.telekom.horizon.starlight.service.TokenService;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-
-@Profile("publisher-mock")
-@Service
 public class TokenServiceMockImpl implements TokenService {
 
     public static final String MOCKED_PUBLISHER_ID = "eni--pandora--foobar";


### PR DESCRIPTION
- Replace custom ObjectMapper instantiation with Spring-managed bean injection in PublisherService and SchemaValidationService
- Remove publishingTimeout config; use Kafka delivery timeout instead (deliveryTimeoutMs: 45000) and call Future.get() without timeout
- Increase graceful shutdown timeout from 30s to 46s to accommodate Kafka delivery timeout
- Pre-compile header propagation blacklist patterns in StarlightConfig via @PostConstruct for better performance
- Remove TokenServiceMockImpl and publisher-mock profile; extract regex pattern to static constant in TokenServiceImpl
- Use writeValueAsString().length() instead of writeValueAsBytes().length for payload size check
- Update tests to reflect DI and profile changes