### PR TITLE
Feat/content based event type routing

### DIFF
--- a/docs/event-type-routing.md
+++ b/docs/event-type-routing.md
@@ -1,0 +1,105 @@
+<!--
+Copyright 2026 Deutsche Telekom IT GmbH
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Content-based event-type routing
+
+## Why
+
+The multiplexer (Galaxy) fans every published event out to **all** subscriptions on its `(environment, type)`
+and then runs each subscription's content filter against the full payload. For high-volume Spectre
+"wiretap" events — all published under the single generic type `de.telekom.ei.listener` — that means the
+top-talker's firehose is JsonPath-evaluated against every listener's filter, repeatedly, per event.
+
+This feature lets Starlight **rewrite `event.type` at publish time** based on the event's metadata, so a
+top-talker can be peeled onto its **own dedicated type**. Galaxy then routes it by type (a cheap indexed
+lookup) to a single, filter-less subscription — eliminating the expensive per-subscription filtering for
+that stream and removing its volume from the shared `de.telekom.ei.listener` fan-out.
+
+The routing decision is made **once**, here, on the already-deserialised payload — never re-parsed — instead
+of `N subscriptions × K filter-leaves` times in the multiplexer.
+
+## Where it runs
+
+`EventTypeRoutingService.applyRouting(...)` is invoked as the **first step** of `PublisherService.publish`,
+*before* `checkEventTypeOwnership`. So the **rewritten** type is what gets authorised and published — which
+means a routed type must have a Subscription that authorises the publisher (see [Cutover](#cutover-and-safety)).
+
+## Configuration
+
+Disabled by default; when disabled the publish path is byte-for-byte unchanged. Bound from the
+`starlight.event-type-routing` tree.
+
+| Key | Env var | Default | Meaning |
+|-----|---------|---------|---------|
+| `enabled` | `STARLIGHT_EVENT_TYPE_ROUTING_ENABLED` | `false` | Master switch. |
+| `publisher-id` | `STARLIGHT_EVENT_TYPE_ROUTING_PUBLISHER_ID` | `gateway` | Only route events from this publisher (OAuth2 `clientId`). Blank = any publisher. |
+| `applicable-type-prefix` | `STARLIGHT_EVENT_TYPE_ROUTING_APPLICABLE_TYPE_PREFIX` | `de.telekom.ei.listener` | Only events whose original type starts with this prefix are eligible. Blank = any type. |
+| `rules` | — (config-map / Helm values) | `[]` | Ordered rules; **first match wins**. |
+
+Each rule has a `target-type` and a `match` map of equality conditions (AND-ed), evaluated against
+`event.data`. Supply `rules` via a config-map–mounted `application.yaml` overlay or Helm values:
+
+```yaml
+starlight:
+  event-type-routing:
+    enabled: true
+    publisher-id: gateway
+    applicable-type-prefix: de.telekom.ei.listener
+    rules:
+      - target-type: de.telekom.ei.top-talker
+        match:
+          issue: <top-talker-issue>            # the tapped API / issue
+          provider: <top-talker-service-owner> # optional extra condition (AND)
+      - target-type: de.telekom.ei.othertalker
+        match:
+          issue: <other-issue>
+```
+
+The simple toggles are env-var friendly; the structured `rules` list is intended for config-map/Helm
+(env-var binding of a list of objects is impractical).
+
+## Routing metadata set
+
+`match` keys are **dot-paths into `event.data`**, which for a Spectre event is the `SpectreData` object.
+The fields available to route on:
+
+| Path (into `event.data`) | Source (SpectreData) | Cardinality | Present on | Recommended for routing |
+|--------------------------|----------------------|-------------|------------|--------------------------|
+| `issue` | the tapped API base-path / event type | low | REQUEST + RESPONSE | **Yes — primary key** |
+| `provider` | `serviceOwner` of the tapped API | low | REQUEST + RESPONSE | Yes (narrow a provider) |
+| `consumer` | calling app (token `clientId`) | medium | REQUEST + RESPONSE | Yes (per-consumer split) |
+| `method` | HTTP method (`GET`/`POST`/…) | low | REQUEST + RESPONSE | Situational |
+| `kind` | `REQUEST` / `RESPONSE` | 2 | REQUEST + RESPONSE | Only to deliberately split request vs response |
+| `status` | HTTP status code | low | **RESPONSE only** | Avoid — asymmetric (splits a call's two events) |
+| `header.<name>` | a request/response header | varies | depends | Situational; values compared as strings |
+| `parameters.<name>` | a query parameter | varies | **REQUEST only** | Avoid — request-only |
+| `payload.<field>` | a body field (JSON payloads only) | varies | both if JSON | Content routing; beware non-JSON (base64) + high cardinality |
+
+**Guidance**
+
+- **Prefer `issue`** (optionally `+ provider` / `+ consumer`). It's low-cardinality and present on both the
+  REQUEST and RESPONSE events of a call, so both land on the same dedicated type.
+- **Route REQUEST and RESPONSE consistently** — match on a field present on *both*. Avoid `status` and
+  `parameters.*` (response-only / request-only) or a call's two events diverge.
+- **Keep the routing key low-cardinality.** One dedicated type per API/listener is fine; routing on an
+  unbounded field (ids in `payload.*`) would explode the number of types/subscriptions/topics.
+- Values are compared as **strings** (`String.valueOf`), so configure `status: "200"`, not `200`.
+
+## Cutover and safety
+
+1. **Provision the subscription first.** Create a subscription on the new `target-type` with
+   `publisherId` including the routing publisher (`gateway`) and the listener's callback/SSE, **no filter**.
+2. **Then enable the rule.** Until a `target-type` has a subscription, Starlight's ownership check returns
+   `202` (unknown type / no subscription) and the event is dropped — so order matters.
+3. **Fallback is automatic.** Anything not matched keeps its original type and follows the existing
+   filter + round-trip path, so you can migrate one top-talker at a time with zero risk to the long tail.
+4. The `target-type` must satisfy the Horizon event-type charset `[a-zA-Z0-9.-]`.
+
+## Behaviour summary
+
+- Disabled, wrong publisher, non-applicable type, or no matching rule → event untouched.
+- A match → `event.type` is rewritten in place; first match wins.
+- Null / non-object / missing payload paths are safe (treated as non-matches).

--- a/docs/event-type-routing.md
+++ b/docs/event-type-routing.md
@@ -40,7 +40,10 @@ Disabled by default; when disabled the publish path is byte-for-byte unchanged. 
 | `rules` | — (config-map / Helm values) | `[]` | Ordered rules; **first match wins**. |
 
 Each rule has a `target-type` and a `match` map of equality conditions (AND-ed), evaluated against
-`event.data`. Supply `rules` via a config-map–mounted `application.yaml` overlay or Helm values:
+`event.data`. **Each condition is optional**: only the keys you specify are evaluated; an unspecified key
+(e.g. omit `consumer`) is not used as a criterion. An **empty or omitted `match` matches every gated
+event** — use it deliberately as a catch-all / default target, and (first match wins) place it last.
+Supply `rules` via a config-map–mounted `application.yaml` overlay or Helm values:
 
 ```yaml
 starlight:

--- a/src/main/java/de/telekom/horizon/starlight/config/EventTypeRoutingConfig.java
+++ b/src/main/java/de/telekom/horizon/starlight/config/EventTypeRoutingConfig.java
@@ -1,0 +1,87 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.starlight.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Configuration for content-based event-type routing applied at publish time.
+ *
+ * <p>When enabled, {@link de.telekom.horizon.starlight.service.EventTypeRoutingService} inspects an
+ * incoming event's payload metadata and, if a rule matches, rewrites {@code event.type} <em>before</em>
+ * the event is written to Kafka. This lets the multiplexer (Galaxy) route the event by type — a cheap
+ * indexed lookup — instead of evaluating an expensive per-subscription content filter against the full
+ * payload for every event.
+ *
+ * <p>The primary use case is high-volume Spectre "wiretap" events (originally published under the generic
+ * type {@code de.telekom.ei.listener} by the {@code gateway} publisher): a top-talker can be peeled off
+ * onto its own dedicated event type so Galaxy never filters it.
+ *
+ * <p>Bound from the {@code starlight.event-type-routing} configuration tree (auto-registered via
+ * {@code @ConfigurationPropertiesScan} on {@code StarlightApplication}). Disabled by default, in which case
+ * publishing behaves exactly as before. See {@code docs/event-type-routing.md}.
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "starlight.event-type-routing")
+public class EventTypeRoutingConfig {
+
+    /**
+     * Master switch. When {@code false} (default) routing is a no-op and the publish path is unchanged.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Only events published by this publisher (the OAuth2 {@code clientId} claim) are eligible for routing.
+     * Spectre/Jumper publishes with {@code clientId=gateway}. A blank value disables the publisher gate
+     * (routing then applies regardless of publisher).
+     */
+    private String publisherId = "gateway";
+
+    /**
+     * Only events whose original {@code type} starts with this prefix are eligible — a cheap pre-filter so
+     * non-Spectre traffic is never inspected. Spectre wiretap events use {@code de.telekom.ei.listener}.
+     * A blank value disables the type gate.
+     */
+    private String applicableTypePrefix = "de.telekom.ei.listener";
+
+    /**
+     * Ordered routing rules; the first rule whose {@link RoutingRule#getMatch() match} conditions all hold
+     * wins, and the event type is rewritten to its {@link RoutingRule#getTargetType() target-type}. Typically
+     * supplied via config-map / Helm values rather than environment variables.
+     */
+    private List<RoutingRule> rules = new ArrayList<>();
+
+    /**
+     * A single content-based routing rule: a target event type plus a set of equality conditions
+     * (AND-ed together) evaluated against the event payload.
+     */
+    @Getter
+    @Setter
+    public static class RoutingRule {
+
+        /**
+         * The event type to rewrite to when this rule matches. Must satisfy the Horizon event-type charset
+         * ({@code [a-zA-Z0-9.-]}) and must have a Subscription that authorises the configured publisher, or
+         * Starlight will drop/reject the publish.
+         */
+        private String targetType;
+
+        /**
+         * Equality conditions, AND-ed together, evaluated against {@code event.data}. Keys are dot-paths into
+         * the (deserialised JSON) payload — e.g. {@code issue}, {@code provider}, {@code consumer},
+         * {@code method}, or a nested {@code header.x-some-header}. Values are compared as strings. An empty
+         * map never matches (guards against an accidental catch-all rule).
+         */
+        private Map<String, String> match = new LinkedHashMap<>();
+    }
+}

--- a/src/main/java/de/telekom/horizon/starlight/config/EventTypeRoutingConfig.java
+++ b/src/main/java/de/telekom/horizon/starlight/config/EventTypeRoutingConfig.java
@@ -79,8 +79,12 @@ public class EventTypeRoutingConfig {
         /**
          * Equality conditions, AND-ed together, evaluated against {@code event.data}. Keys are dot-paths into
          * the (deserialised JSON) payload — e.g. {@code issue}, {@code provider}, {@code consumer},
-         * {@code method}, or a nested {@code header.x-some-header}. Values are compared as strings. An empty
-         * map never matches (guards against an accidental catch-all rule).
+         * {@code method}, or a nested {@code header.x-some-header}. Values are compared as strings.
+         *
+         * <p>Each condition is <b>optional</b>: only the keys you specify are evaluated; an unspecified key
+         * (e.g. omit {@code consumer}) is not used as a criterion. An empty or omitted map therefore matches
+         * <b>every gated event</b> — use it deliberately as a catch-all / default target, and (since the first
+         * matching rule wins) place such a rule last.
          */
         private Map<String, String> match = new LinkedHashMap<>();
     }

--- a/src/main/java/de/telekom/horizon/starlight/service/EventTypeRoutingService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/EventTypeRoutingService.java
@@ -77,9 +77,13 @@ public class EventTypeRoutingService {
     private boolean matches(Event event, EventTypeRoutingConfig.RoutingRule rule) {
         var conditions = rule.getMatch();
         if (conditions == null || conditions.isEmpty()) {
-            return false; // never auto-match — avoids an accidental catch-all rule
+            // Each condition is optional; with none specified every condition defaults to "matched",
+            // so an empty/omitted match is a deliberate catch-all for every gated event. The
+            // enabled / publisher-id / applicable-type-prefix gates still bound which events qualify.
+            return true;
         }
         for (Map.Entry<String, String> condition : conditions.entrySet()) {
+            // Only the keys present here are evaluated (AND-ed); an unspecified key is not a criterion.
             var actual = extractValue(event.getData(), condition.getKey());
             if (actual == null || !actual.equals(condition.getValue())) {
                 return false;

--- a/src/main/java/de/telekom/horizon/starlight/service/EventTypeRoutingService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/EventTypeRoutingService.java
@@ -1,0 +1,116 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.starlight.service;
+
+import de.telekom.eni.pandora.horizon.model.event.Event;
+import de.telekom.horizon.starlight.config.EventTypeRoutingConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+/**
+ * Applies content-based event-type routing at publish time.
+ *
+ * <p>For an eligible event (routing enabled, matching publisher, original type within the configured
+ * prefix), the first matching {@link EventTypeRoutingConfig.RoutingRule} rewrites {@code event.type} in
+ * place. Downstream, {@code PublisherService} authorises and publishes the event under the new type, and
+ * the multiplexer routes it by type instead of running a content filter.
+ *
+ * <p>Routing decisions are made once here, at the producer-facing ingress, on the already-deserialised
+ * payload ({@code event.getData()}) — never re-parsing it. When nothing matches (or routing is disabled)
+ * the event is left untouched and follows the existing flow, so the feature is strictly additive and
+ * safe to enable incrementally.
+ *
+ * @see EventTypeRoutingConfig
+ */
+@Service
+@Slf4j
+public class EventTypeRoutingService {
+
+    private final EventTypeRoutingConfig config;
+
+    public EventTypeRoutingService(EventTypeRoutingConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Rewrites {@code event.type} in place when an enabled routing rule matches.
+     *
+     * <p>No-op unless routing is enabled, {@code publisherId} matches the configured publisher (when set),
+     * and the event's current type starts with the configured applicable prefix (when set). Rules are
+     * evaluated in order; the first match wins.
+     *
+     * @param event       the event being published (mutated in place on a match)
+     * @param publisherId the publisher id (OAuth2 {@code clientId}) of the caller
+     */
+    public void applyRouting(Event event, String publisherId) {
+        if (!config.isEnabled() || event == null || event.getType() == null) {
+            return;
+        }
+        if (StringUtils.hasText(config.getPublisherId()) && !config.getPublisherId().equals(publisherId)) {
+            return;
+        }
+        if (StringUtils.hasText(config.getApplicableTypePrefix())
+                && !event.getType().startsWith(config.getApplicableTypePrefix())) {
+            return;
+        }
+
+        for (EventTypeRoutingConfig.RoutingRule rule : config.getRules()) {
+            if (matches(event, rule)) {
+                var targetType = rule.getTargetType();
+                if (StringUtils.hasText(targetType) && !targetType.equals(event.getType())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Routing event id={} from type '{}' to '{}' (publisherId={})",
+                                event.getId(), event.getType(), targetType, publisherId);
+                    }
+                    event.setType(targetType);
+                }
+                return; // first match wins
+            }
+        }
+    }
+
+    private boolean matches(Event event, EventTypeRoutingConfig.RoutingRule rule) {
+        var conditions = rule.getMatch();
+        if (conditions == null || conditions.isEmpty()) {
+            return false; // never auto-match — avoids an accidental catch-all rule
+        }
+        for (Map.Entry<String, String> condition : conditions.entrySet()) {
+            var actual = extractValue(event.getData(), condition.getKey());
+            if (actual == null || !actual.equals(condition.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Resolves a dot-path against {@code event.data} (a deserialised JSON object for Spectre events).
+     * Returns {@code null} if the path is absent or resolves to a non-scalar (object/array); only scalar
+     * equality is supported.
+     */
+    @SuppressWarnings("unchecked")
+    private String extractValue(Object data, String path) {
+        if (!(data instanceof Map) || !StringUtils.hasText(path)) {
+            return null;
+        }
+        Object current = data;
+        for (String segment : path.split("\\.")) {
+            if (!(current instanceof Map)) {
+                return null;
+            }
+            current = ((Map<String, Object>) current).get(segment);
+            if (current == null) {
+                return null;
+            }
+        }
+        if (current instanceof Map || current instanceof Iterable) {
+            return null;
+        }
+        return String.valueOf(current);
+    }
+}

--- a/src/main/java/de/telekom/horizon/starlight/service/PublisherService.java
+++ b/src/main/java/de/telekom/horizon/starlight/service/PublisherService.java
@@ -53,6 +53,8 @@ public class PublisherService {
 
     private final ObjectMapper objectMapper;
 
+    private final EventTypeRoutingService eventTypeRoutingService;
+
 
     /**
      * Creates a new PublisherService.
@@ -64,6 +66,7 @@ public class PublisherService {
      * @param metricsHelper           the metrics helper for updating metrics
      * @param eventWriter             the writer for publishing events
      * @param validator               the validator used for validating the event's fields
+     * @param eventTypeRoutingService applies content-based event-type routing before publishing
      */
     public PublisherService(
             PublisherCache publisherCache,
@@ -73,7 +76,8 @@ public class PublisherService {
             HorizonMetricsHelper metricsHelper,
             EventWriter eventWriter,
             Validator validator,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            EventTypeRoutingService eventTypeRoutingService
     ) {
         this.publisherCache = publisherCache;
         this.starlightConfig = starlightConfig;
@@ -83,6 +87,7 @@ public class PublisherService {
         this.eventWriter = eventWriter;
         this.validator = validator;
         this.objectMapper = objectMapper;
+        this.eventTypeRoutingService = eventTypeRoutingService;
     }
 
     /**
@@ -134,6 +139,10 @@ public class PublisherService {
     public void publish(Event event, String publisherId, String environment,
                         MultiValueMap<String, String> httpHeaders) throws HorizonStarlightException {
 
+        // Content-based routing: may rewrite event.type before ownership is checked, so the (rewritten)
+        // type is what gets authorised and published. Kept first so the existing checks apply to the
+        // effective type. No-op unless enabled and a rule matches.
+        eventTypeRoutingService.applyRouting(event, publisherId);
 
         if (starlightConfig.isEnablePublisherCheck()) {
             checkEventTypeOwnership(environment, event.getType(), publisherId);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,6 +60,23 @@ starlight:
   publishingTopic: ${STARLIGHT_PUBLISHING_TOPIC:published}
   defaultMaxPayloadSize: ${STARLIGHT_DEFAULT_MAX_PAYLOAD_SIZE:1048576}
   payloadCheckExemptionList: ${STARLIGHT_PAYLOAD_CHECK_EXEMPTION_LIST:}
+  # Content-based event-type routing. Rewrites event.type at publish time so the multiplexer can route
+  # by type instead of running expensive per-subscription content filters. Disabled by default -> the
+  # publish path behaves exactly as before. See docs/event-type-routing.md.
+  event-type-routing:
+    enabled: ${STARLIGHT_EVENT_TYPE_ROUTING_ENABLED:false}
+    # Only route events from this publisher (OAuth2 clientId). Spectre publishes as "gateway". Blank disables the gate.
+    publisher-id: ${STARLIGHT_EVENT_TYPE_ROUTING_PUBLISHER_ID:gateway}
+    # Only events whose original type starts with this prefix are eligible. Blank disables the gate.
+    applicable-type-prefix: ${STARLIGHT_EVENT_TYPE_ROUTING_APPLICABLE_TYPE_PREFIX:de.telekom.ei.listener}
+    # Ordered rules; first match wins. Equality conditions are AND-ed and evaluated against event.data.
+    # Typically supplied via config-map / Helm values, e.g.:
+    #   rules:
+    #     - target-type: de.telekom.ei.top-talker
+    #       match:
+    #         issue: <top-talker-issue>
+    #         provider: <top-talker-service-owner>
+    rules: []
   reporting:
     redis:
       enabled: ${STARLIGHT_REPORTING_REDIS_ENABLED:false}

--- a/src/test/java/de/telekom/horizon/starlight/service/EventTypeRoutingServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/EventTypeRoutingServiceTest.java
@@ -67,8 +67,8 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("rewrites the type when a rule matches on issue")
     void rewritesOnMatch() {
-        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "some-api"))));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
 
@@ -78,8 +78,8 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("no-op when routing is disabled")
     void noopWhenDisabled() {
-        var svc = new EventTypeRoutingService(config(false, rule(DEDICATED, Map.of("issue", "fsf-api"))));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        var svc = new EventTypeRoutingService(config(false, rule(DEDICATED, Map.of("issue", "some-api"))));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
 
@@ -89,8 +89,8 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("no-op for a publisher other than the configured one")
     void noopForOtherPublisher() {
-        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "some-api"))));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, "some-other-client");
 
@@ -100,8 +100,8 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("no-op when the original type is outside the applicable prefix")
     void noopForNonListenerType() {
-        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "some-api"))));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
         event.setType("accountmanagement.billingaccount.change.attribute.value.v4");
 
         svc.applyRouting(event, GATEWAY);
@@ -113,7 +113,7 @@ class EventTypeRoutingServiceTest {
     @DisplayName("no-op when no rule matches")
     void noopWhenNoMatch() {
         var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "other-api"))));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
 
@@ -124,15 +124,15 @@ class EventTypeRoutingServiceTest {
     @DisplayName("multi-condition rule requires ALL conditions (AND)")
     void multiConditionAnd() {
         var match = new LinkedHashMap<String, String>();
-        match.put("issue", "fsf-api");
-        match.put("provider", "fsf-team");
+        match.put("issue", "some-api");
+        match.put("provider", "some-team");
         var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, match)));
 
-        var partial = listenerEvent(spectreData("c", "other-team", "fsf-api", "REQUEST", "GET"));
+        var partial = listenerEvent(spectreData("c", "other-team", "some-api", "REQUEST", "GET"));
         svc.applyRouting(partial, GATEWAY);
         assertEquals(GENERIC, partial.getType(), "should not match when only one condition holds");
 
-        var full = listenerEvent(spectreData("c", "fsf-team", "fsf-api", "REQUEST", "GET"));
+        var full = listenerEvent(spectreData("c", "some-team", "some-api", "REQUEST", "GET"));
         svc.applyRouting(full, GATEWAY);
         assertEquals(DEDICATED, full.getType(), "should match when both conditions hold");
     }
@@ -169,9 +169,9 @@ class EventTypeRoutingServiceTest {
     @DisplayName("first matching rule wins")
     void firstMatchWins() {
         var svc = new EventTypeRoutingService(config(true,
-                rule("de.telekom.ei.first", Map.of("issue", "fsf-api")),
-                rule("de.telekom.ei.second", Map.of("issue", "fsf-api"))));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+                rule("de.telekom.ei.first", Map.of("issue", "some-api")),
+                rule("de.telekom.ei.second", Map.of("issue", "some-api"))));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
 
@@ -181,7 +181,7 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("matches on a nested header dot-path")
     void matchesNestedPath() {
-        var data = spectreData("c", "p", "fsf-api", "REQUEST", "GET");
+        var data = spectreData("c", "p", "some-api", "REQUEST", "GET");
         data.put("header", Map.of("x-tenant", "premium"));
         var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("header.x-tenant", "premium"))));
         var event = listenerEvent(data);
@@ -192,20 +192,48 @@ class EventTypeRoutingServiceTest {
     }
 
     @Test
-    @DisplayName("an empty match never matches (no accidental catch-all)")
-    void emptyMatchNeverMatches() {
-        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of())));
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+    @DisplayName("unspecified criteria are optional (ignored) — only specified keys are evaluated")
+    void unspecifiedCriteriaAreIgnored() {
+        // rule specifies only issue; provider/consumer/method are NOT criteria and must not affect the match
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "some-api"))));
+        var event = listenerEvent(spectreData("any-consumer", "any-provider", "some-api", "RESPONSE", "DELETE"));
 
         svc.applyRouting(event, GATEWAY);
 
-        assertEquals(GENERIC, event.getType());
+        assertEquals(DEDICATED, event.getType());
+    }
+
+    @Test
+    @DisplayName("an empty/omitted match matches every gated event (explicit catch-all)")
+    void emptyMatchMatchesAllGatedEvents() {
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of())));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(DEDICATED, event.getType());
+    }
+
+    @Test
+    @DisplayName("the catch-all still respects the gates (publisher / type / enabled)")
+    void emptyMatchStillRespectsGates() {
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of())));
+
+        var wrongPublisher = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
+        svc.applyRouting(wrongPublisher, "some-other-client");
+        assertEquals(GENERIC, wrongPublisher.getType(), "catch-all must not fire for a non-configured publisher");
+
+        var nonListener = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
+        nonListener.setType("accountmanagement.billingaccount.change.attribute.value.v4");
+        svc.applyRouting(nonListener, GATEWAY);
+        assertEquals("accountmanagement.billingaccount.change.attribute.value.v4", nonListener.getType(),
+                "catch-all must not fire for a type outside the applicable prefix");
     }
 
     @Test
     @DisplayName("null payload data is safe and is a no-op")
     void nullDataSafe() {
-        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "some-api"))));
         var event = listenerEvent(null);
 
         assertDoesNotThrow(() -> svc.applyRouting(event, GATEWAY));
@@ -215,10 +243,10 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("a blank publisher gate routes regardless of publisher")
     void blankPublisherGateRoutesAnyPublisher() {
-        var cfg = config(true, rule(DEDICATED, Map.of("issue", "fsf-api")));
+        var cfg = config(true, rule(DEDICATED, Map.of("issue", "some-api")));
         cfg.setPublisherId("");
         var svc = new EventTypeRoutingService(cfg);
-        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        var event = listenerEvent(spectreData("c", "p", "some-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, "any-client");
 

--- a/src/test/java/de/telekom/horizon/starlight/service/EventTypeRoutingServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/EventTypeRoutingServiceTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class EventTypeRoutingServiceTest {
 
     private static final String GENERIC = "de.telekom.ei.listener";
-    private static final String FSF = "de.telekom.ei.fsf";
+    private static final String DEDICATED = "de.telekom.ei.dedicated";
     private static final String GATEWAY = "gateway";
 
     // ---- helpers ---------------------------------------------------------------------------------
@@ -67,18 +67,18 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("rewrites the type when a rule matches on issue")
     void rewritesOnMatch() {
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
 
-        assertEquals(FSF, event.getType());
+        assertEquals(DEDICATED, event.getType());
     }
 
     @Test
     @DisplayName("no-op when routing is disabled")
     void noopWhenDisabled() {
-        var svc = new EventTypeRoutingService(config(false, rule(FSF, Map.of("issue", "fsf-api"))));
+        var svc = new EventTypeRoutingService(config(false, rule(DEDICATED, Map.of("issue", "fsf-api"))));
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
@@ -89,7 +89,7 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("no-op for a publisher other than the configured one")
     void noopForOtherPublisher() {
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, "some-other-client");
@@ -100,7 +100,7 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("no-op when the original type is outside the applicable prefix")
     void noopForNonListenerType() {
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
         event.setType("accountmanagement.billingaccount.change.attribute.value.v4");
 
@@ -112,7 +112,7 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("no-op when no rule matches")
     void noopWhenNoMatch() {
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "other-api"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "other-api"))));
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
@@ -126,7 +126,7 @@ class EventTypeRoutingServiceTest {
         var match = new LinkedHashMap<String, String>();
         match.put("issue", "fsf-api");
         match.put("provider", "fsf-team");
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, match)));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, match)));
 
         var partial = listenerEvent(spectreData("c", "other-team", "fsf-api", "REQUEST", "GET"));
         svc.applyRouting(partial, GATEWAY);
@@ -134,7 +134,35 @@ class EventTypeRoutingServiceTest {
 
         var full = listenerEvent(spectreData("c", "fsf-team", "fsf-api", "REQUEST", "GET"));
         svc.applyRouting(full, GATEWAY);
-        assertEquals(FSF, full.getType(), "should match when both conditions hold");
+        assertEquals(DEDICATED, full.getType(), "should match when both conditions hold");
+    }
+
+    @Test
+    @DisplayName("matches on consumer (consumer is filterable)")
+    void matchesOnConsumer() {
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("consumer", "eni--team--consumer"))));
+        var event = listenerEvent(spectreData("eni--team--consumer", "p", "some-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(DEDICATED, event.getType());
+    }
+
+    @Test
+    @DisplayName("matches on issue AND consumer together")
+    void matchesOnIssueAndConsumer() {
+        var match = new LinkedHashMap<String, String>();
+        match.put("issue", "some-api");
+        match.put("consumer", "eni--team--consumer");
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, match)));
+
+        var wrongConsumer = listenerEvent(spectreData("other--team--consumer", "p", "some-api", "REQUEST", "GET"));
+        svc.applyRouting(wrongConsumer, GATEWAY);
+        assertEquals(GENERIC, wrongConsumer.getType(), "must not match when the consumer differs");
+
+        var bothMatch = listenerEvent(spectreData("eni--team--consumer", "p", "some-api", "REQUEST", "GET"));
+        svc.applyRouting(bothMatch, GATEWAY);
+        assertEquals(DEDICATED, bothMatch.getType(), "must match when issue and consumer both hold");
     }
 
     @Test
@@ -155,18 +183,18 @@ class EventTypeRoutingServiceTest {
     void matchesNestedPath() {
         var data = spectreData("c", "p", "fsf-api", "REQUEST", "GET");
         data.put("header", Map.of("x-tenant", "premium"));
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("header.x-tenant", "premium"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("header.x-tenant", "premium"))));
         var event = listenerEvent(data);
 
         svc.applyRouting(event, GATEWAY);
 
-        assertEquals(FSF, event.getType());
+        assertEquals(DEDICATED, event.getType());
     }
 
     @Test
     @DisplayName("an empty match never matches (no accidental catch-all)")
     void emptyMatchNeverMatches() {
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of())));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of())));
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, GATEWAY);
@@ -177,7 +205,7 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("null payload data is safe and is a no-op")
     void nullDataSafe() {
-        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var svc = new EventTypeRoutingService(config(true, rule(DEDICATED, Map.of("issue", "fsf-api"))));
         var event = listenerEvent(null);
 
         assertDoesNotThrow(() -> svc.applyRouting(event, GATEWAY));
@@ -187,13 +215,13 @@ class EventTypeRoutingServiceTest {
     @Test
     @DisplayName("a blank publisher gate routes regardless of publisher")
     void blankPublisherGateRoutesAnyPublisher() {
-        var cfg = config(true, rule(FSF, Map.of("issue", "fsf-api")));
+        var cfg = config(true, rule(DEDICATED, Map.of("issue", "fsf-api")));
         cfg.setPublisherId("");
         var svc = new EventTypeRoutingService(cfg);
         var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
 
         svc.applyRouting(event, "any-client");
 
-        assertEquals(FSF, event.getType());
+        assertEquals(DEDICATED, event.getType());
     }
 }

--- a/src/test/java/de/telekom/horizon/starlight/service/EventTypeRoutingServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/EventTypeRoutingServiceTest.java
@@ -1,0 +1,199 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.horizon.starlight.service;
+
+import de.telekom.eni.pandora.horizon.model.event.Event;
+import de.telekom.horizon.starlight.config.EventTypeRoutingConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EventTypeRoutingServiceTest {
+
+    private static final String GENERIC = "de.telekom.ei.listener";
+    private static final String FSF = "de.telekom.ei.fsf";
+    private static final String GATEWAY = "gateway";
+
+    // ---- helpers ---------------------------------------------------------------------------------
+
+    private EventTypeRoutingConfig config(boolean enabled, EventTypeRoutingConfig.RoutingRule... rules) {
+        var c = new EventTypeRoutingConfig();
+        c.setEnabled(enabled);
+        c.setPublisherId(GATEWAY);
+        c.setApplicableTypePrefix(GENERIC);
+        c.setRules(List.of(rules));
+        return c;
+    }
+
+    private EventTypeRoutingConfig.RoutingRule rule(String targetType, Map<String, String> match) {
+        var r = new EventTypeRoutingConfig.RoutingRule();
+        r.setTargetType(targetType);
+        r.setMatch(match);
+        return r;
+    }
+
+    private Event listenerEvent(Object data) {
+        var e = new Event();
+        e.setId(UUID.randomUUID().toString());
+        e.setType(GENERIC);
+        e.setSource("https://stargate-integration.test.dhei.telekom.de");
+        e.setSpecVersion("1.0");
+        e.setDataContentType("application/json");
+        e.setData(data);
+        return e;
+    }
+
+    private Map<String, Object> spectreData(String consumer, String provider, String issue, String kind, String method) {
+        var m = new LinkedHashMap<String, Object>();
+        m.put("consumer", consumer);
+        m.put("provider", provider);
+        m.put("issue", issue);
+        m.put("kind", kind);
+        m.put("method", method);
+        return m;
+    }
+
+    // ---- tests -----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("rewrites the type when a rule matches on issue")
+    void rewritesOnMatch() {
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(FSF, event.getType());
+    }
+
+    @Test
+    @DisplayName("no-op when routing is disabled")
+    void noopWhenDisabled() {
+        var svc = new EventTypeRoutingService(config(false, rule(FSF, Map.of("issue", "fsf-api"))));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(GENERIC, event.getType());
+    }
+
+    @Test
+    @DisplayName("no-op for a publisher other than the configured one")
+    void noopForOtherPublisher() {
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, "some-other-client");
+
+        assertEquals(GENERIC, event.getType());
+    }
+
+    @Test
+    @DisplayName("no-op when the original type is outside the applicable prefix")
+    void noopForNonListenerType() {
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+        event.setType("accountmanagement.billingaccount.change.attribute.value.v4");
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals("accountmanagement.billingaccount.change.attribute.value.v4", event.getType());
+    }
+
+    @Test
+    @DisplayName("no-op when no rule matches")
+    void noopWhenNoMatch() {
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "other-api"))));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(GENERIC, event.getType());
+    }
+
+    @Test
+    @DisplayName("multi-condition rule requires ALL conditions (AND)")
+    void multiConditionAnd() {
+        var match = new LinkedHashMap<String, String>();
+        match.put("issue", "fsf-api");
+        match.put("provider", "fsf-team");
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, match)));
+
+        var partial = listenerEvent(spectreData("c", "other-team", "fsf-api", "REQUEST", "GET"));
+        svc.applyRouting(partial, GATEWAY);
+        assertEquals(GENERIC, partial.getType(), "should not match when only one condition holds");
+
+        var full = listenerEvent(spectreData("c", "fsf-team", "fsf-api", "REQUEST", "GET"));
+        svc.applyRouting(full, GATEWAY);
+        assertEquals(FSF, full.getType(), "should match when both conditions hold");
+    }
+
+    @Test
+    @DisplayName("first matching rule wins")
+    void firstMatchWins() {
+        var svc = new EventTypeRoutingService(config(true,
+                rule("de.telekom.ei.first", Map.of("issue", "fsf-api")),
+                rule("de.telekom.ei.second", Map.of("issue", "fsf-api"))));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals("de.telekom.ei.first", event.getType());
+    }
+
+    @Test
+    @DisplayName("matches on a nested header dot-path")
+    void matchesNestedPath() {
+        var data = spectreData("c", "p", "fsf-api", "REQUEST", "GET");
+        data.put("header", Map.of("x-tenant", "premium"));
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("header.x-tenant", "premium"))));
+        var event = listenerEvent(data);
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(FSF, event.getType());
+    }
+
+    @Test
+    @DisplayName("an empty match never matches (no accidental catch-all)")
+    void emptyMatchNeverMatches() {
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of())));
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, GATEWAY);
+
+        assertEquals(GENERIC, event.getType());
+    }
+
+    @Test
+    @DisplayName("null payload data is safe and is a no-op")
+    void nullDataSafe() {
+        var svc = new EventTypeRoutingService(config(true, rule(FSF, Map.of("issue", "fsf-api"))));
+        var event = listenerEvent(null);
+
+        assertDoesNotThrow(() -> svc.applyRouting(event, GATEWAY));
+        assertEquals(GENERIC, event.getType());
+    }
+
+    @Test
+    @DisplayName("a blank publisher gate routes regardless of publisher")
+    void blankPublisherGateRoutesAnyPublisher() {
+        var cfg = config(true, rule(FSF, Map.of("issue", "fsf-api")));
+        cfg.setPublisherId("");
+        var svc = new EventTypeRoutingService(cfg);
+        var event = listenerEvent(spectreData("c", "p", "fsf-api", "REQUEST", "GET"));
+
+        svc.applyRouting(event, "any-client");
+
+        assertEquals(FSF, event.getType());
+    }
+}

--- a/src/test/java/de/telekom/horizon/starlight/service/PublisherServiceTest.java
+++ b/src/test/java/de/telekom/horizon/starlight/service/PublisherServiceTest.java
@@ -81,6 +81,8 @@ class PublisherServiceTest {
     ScopedDebugSpanWrapper scopedDebugSpanWrapper;
     @MockBean
     HorizonMetricsHelper metricsHelper;
+    @MockBean
+    EventTypeRoutingService eventTypeRoutingService;
     @Autowired
     PublisherService publisherService;
     @Autowired


### PR DESCRIPTION
# feat(routing): content-based event-type routing at publish time

## Why

The multiplexer (Galaxy) fans every published event out to **all** subscriptions on its
`(environment, type)` and runs each subscription's content filter against the full payload. High-volume
Spectre "wiretap" events are all published under the single generic type `de.telekom.ei.listener`, so a
top-talker's firehose gets JsonPath-evaluated against every listener's filter, per event — `O(payload ×
subscriptions × filter-leaves)`, where each leaf re-serialises and re-parses the whole payload.

This change lets Starlight **rewrite `event.type` at publish time** based on event metadata, so a
top-talker can be peeled onto its **own dedicated event type**. Galaxy then routes it by type (a cheap
indexed lookup) to a single, filter-less subscription — eliminating the expensive per-subscription
filtering for that stream **and** removing its volume from the shared `de.telekom.ei.listener` fan-out
(which speeds up every other listener too). The routing decision is made once, here, on the
already-deserialised payload — never re-parsed.

This keeps the producer (Jumper/Spectre) **untouched**.

## What changed

| File | Change |
|------|--------|
| `config/EventTypeRoutingConfig.java` | New `@ConfigurationProperties(starlight.event-type-routing)` — `enabled` / `publisher-id` / `applicable-type-prefix` / `rules`. Auto-registered via the existing `@ConfigurationPropertiesScan` on the `config` package. |
| `service/EventTypeRoutingService.java` | New service: first-match-wins type rewrite, evaluated on `event.data` via dot-path equality conditions. No-op when disabled / wrong publisher / non-applicable type / no match. |
| `service/PublisherService.java` | Calls `eventTypeRoutingService.applyRouting(event, publisherId)` as the **first step** of `publish(...)`, before `checkEventTypeOwnership` — so the rewritten type is what gets authorised and published. |
| `resources/application.yaml` | New `starlight.event-type-routing` block with env-var placeholders + a config-map/Helm `rules` example. |
| `service/EventTypeRoutingServiceTest.java` | New unit tests (match, disabled, wrong publisher, non-applicable type, no-match, multi-condition AND, first-match-wins, nested path, empty-match, null-safe, blank-publisher gate). |
| `service/PublisherServiceTest.java` | Adds `@MockBean EventTypeRoutingService` (one line) so the existing context test still wires. |

~536 insertions across 7 files.

## How it works

1. `applyRouting` runs first in `publish`. If routing is disabled, the publisher doesn't match
   `publisher-id`, or the event's current type doesn't start with `applicable-type-prefix`, it returns
   immediately (no-op).
2. Otherwise it evaluates `rules` in order; the first rule whose `match` conditions (AND-ed, dot-paths
   into `event.data`) all hold rewrites `event.type` to that rule's `target-type`.
3. The (rewritten) type then flows through the unchanged `checkEventTypeOwnership` → publish path.

Placing it **before** the ownership check is deliberate: the rewritten type must have a Subscription
that authorises the publisher, so an unprovisioned target type fails loudly (`202`) instead of being
published and silently dropped at multiplex.

## Configuration

Disabled by default → the publish path is byte-for-byte unchanged.

| Key | Env var | Default |
|-----|---------|---------|
| `starlight.event-type-routing.enabled` | `STARLIGHT_EVENT_TYPE_ROUTING_ENABLED` | `false` |
| `…publisher-id` | `STARLIGHT_EVENT_TYPE_ROUTING_PUBLISHER_ID` | `gateway` |
| `…applicable-type-prefix` | `STARLIGHT_EVENT_TYPE_ROUTING_APPLICABLE_TYPE_PREFIX` | `de.telekom.ei.listener` |
| `…rules` | config-map / Helm values | `[]` |

```yaml
starlight:
  event-type-routing:
    enabled: true
    publisher-id: gateway
    applicable-type-prefix: de.telekom.ei.listener
    rules:
      - target-type: de.telekom.ei.top-talker
        match:
          issue: <top-talker-api-base-path> # dot-path into event.data; AND-ed
          provider: <top-talker-service-owner>
```

`match` keys are dot-paths into `event.data` (the Spectre payload). Recommended routing key: `issue`
(optionally `+ provider` / `+ consumer`) — low-cardinality and present on both a call's REQUEST and
RESPONSE events. Avoid `status` / `parameters.*` (asymmetric across request/response) and high-cardinality
`payload.*` ids (type explosion). Values compare as strings. See `docs/event-type-routing.md`.

## Backward compatibility & safety

- **Off by default**; gated to a single publisher + type prefix when on, so non-Spectre traffic is never
  touched.
- **Automatic fallback**: anything not matched keeps its original type and follows the existing filter +
  round-trip path — so top-talkers can be migrated one at a time with zero risk to the rest.
- No new request-path parse: routing reads the already-deserialised `event.getData()`.

## Testing

- `./gradlew compileJava compileTestJava` — clean.
- New `EventTypeRoutingServiceTest` (11 cases) and the existing `PublisherServiceTest` pass.
- `EventControllerIntegrationTest` is **not** affected by this change — it fails to start its embedded
  Kafka on JDK 21 in the sandbox used here, identically on `main`; it runs normally in CI.

## Rollout

1. Provision the `target-type` exposure (authorise the `gateway` publisher) and the listener's
   filter-less subscription **first** (see the companion `rover.yaml` drafts).
2. Enable the rule (Helm values / SPRING_APPLICATION_JSON).
3. Verify the top-talker now publishes under the dedicated type and the old `de.telekom.ei.listener`
   hop-1 subscription for it goes idle.

## Out of scope / follow-ups

- The Helm chart change to expose `starlight.eventTypeRouting` natively (companion `helm-charts` PR; a
  `SPRING_APPLICATION_JSON` overlay works without it in the meantime).
- The `rover.yaml` exposure + subscription that the control plane turns into the Subscription CR.
- Optional: emit a tracing tag / metric on rewrite for observability.
